### PR TITLE
Add comprehensive benchmark suite

### DIFF
--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -1,9 +1,13 @@
 # Makefile for golars benchmarks
 
-.PHONY: all generate benchmark-groupby benchmark-all compare clean help
+.PHONY: all generate benchmark-all benchmark-groupby benchmark-filter benchmark-join benchmark-sort benchmark-agg benchmark-io compare clean help
 
 # Default data size
 SIZE ?= medium
+
+# Benchmark settings
+COUNT ?= 3
+TIMEOUT ?= 30m
 
 # Directories
 DATA_DIR = data
@@ -11,18 +15,26 @@ RESULTS_DIR = results
 
 help:
 	@echo "golars Benchmark Commands:"
+	@echo ""
 	@echo "  make generate          - Generate test data"
+	@echo "  make benchmark-all     - Run all benchmark suites"
 	@echo "  make benchmark-groupby - Run group-by benchmarks"
-	@echo "  make benchmark-all     - Run all benchmarks"
+	@echo "  make benchmark-filter  - Run filter benchmarks"
+	@echo "  make benchmark-join    - Run join benchmarks"
+	@echo "  make benchmark-sort    - Run sort benchmarks"
+	@echo "  make benchmark-agg     - Run aggregation benchmarks"
+	@echo "  make benchmark-io      - Run I/O benchmarks"
 	@echo "  make compare           - Compare with Polars"
+	@echo "  make report            - Generate benchmark report"
 	@echo "  make clean             - Clean generated files"
 	@echo ""
 	@echo "Options:"
 	@echo "  SIZE=small|medium|large - Set data size (default: medium)"
+	@echo "  COUNT=N                  - Number of benchmark runs (default: 3)"
 	@echo ""
 	@echo "Examples:"
 	@echo "  make generate SIZE=large"
-	@echo "  make benchmark-groupby SIZE=small"
+	@echo "  make benchmark-all SIZE=small COUNT=5"
 
 # Create necessary directories
 $(RESULTS_DIR):
@@ -36,25 +48,60 @@ generate: $(DATA_DIR)
 	@echo "Generating $(SIZE) H2O.ai dataset..."
 	go run cmd/generate/main.go -size $(SIZE) -format parquet
 
-# Run group-by benchmarks
+# Individual benchmark suites
 benchmark-groupby: $(RESULTS_DIR)
-	@echo "Running group-by benchmarks with $(SIZE) data..."
-	go test -bench=".*_$(shell echo $(SIZE) | sed 's/\b\(.\)/\u\1/')" ./groupby -benchmem -count=5 | tee $(RESULTS_DIR)/golars_groupby_$(SIZE).txt
+	@echo "Running group-by benchmarks..."
+	go test -bench=. ./groupby -benchmem -count=$(COUNT) -timeout=$(TIMEOUT) | tee $(RESULTS_DIR)/groupby_$(SIZE).txt
+
+benchmark-filter: $(RESULTS_DIR)
+	@echo "Running filter benchmarks..."
+	go test -bench=. ./filter -benchmem -count=$(COUNT) -timeout=$(TIMEOUT) | tee $(RESULTS_DIR)/filter_$(SIZE).txt
+
+benchmark-join: $(RESULTS_DIR)
+	@echo "Running join benchmarks..."
+	go test -bench=. ./join -benchmem -count=$(COUNT) -timeout=$(TIMEOUT) | tee $(RESULTS_DIR)/join_$(SIZE).txt
+
+benchmark-sort: $(RESULTS_DIR)
+	@echo "Running sort benchmarks..."
+	go test -bench=. ./sort -benchmem -count=$(COUNT) -timeout=$(TIMEOUT) | tee $(RESULTS_DIR)/sort_$(SIZE).txt
+
+benchmark-agg: $(RESULTS_DIR)
+	@echo "Running aggregation benchmarks..."
+	go test -bench=. ./agg -benchmem -count=$(COUNT) -timeout=$(TIMEOUT) | tee $(RESULTS_DIR)/agg_$(SIZE).txt
+
+benchmark-io: $(RESULTS_DIR)
+	@echo "Running I/O benchmarks..."
+	go test -bench=. ./io -benchmem -count=$(COUNT) -timeout=$(TIMEOUT) | tee $(RESULTS_DIR)/io_$(SIZE).txt
 
 # Run all benchmarks
-benchmark-all: benchmark-groupby
-	@echo "All benchmarks completed."
+benchmark-all: $(RESULTS_DIR)
+	@echo "Running all golars benchmarks with $(SIZE) data..."
+	@echo "================================================"
+	@$(MAKE) benchmark-agg SIZE=$(SIZE) COUNT=$(COUNT)
+	@$(MAKE) benchmark-filter SIZE=$(SIZE) COUNT=$(COUNT)
+	@$(MAKE) benchmark-sort SIZE=$(SIZE) COUNT=$(COUNT)
+	@$(MAKE) benchmark-groupby SIZE=$(SIZE) COUNT=$(COUNT)
+	@$(MAKE) benchmark-join SIZE=$(SIZE) COUNT=$(COUNT)
+	@$(MAKE) benchmark-io SIZE=$(SIZE) COUNT=$(COUNT)
+	@echo "================================================"
+	@echo "All benchmarks completed. Results in $(RESULTS_DIR)/"
 
 # Compare with Polars
 compare: $(RESULTS_DIR)
 	@echo "Running comparison with Polars..."
-	cd compare && ./run_comparison.sh all $(SIZE)
+	cd compare && python run_polars_benchmarks.py --size $(SIZE)
+	python compare/analyze.py --size $(SIZE)
+
+# Generate report from existing results
+report: $(RESULTS_DIR)
+	@echo "Generating benchmark report..."
+	python compare/analyze.py --size $(SIZE) --report $(RESULTS_DIR)/report_$(SIZE).md
 
 # Clean generated files
 clean:
 	rm -rf $(RESULTS_DIR)
 	rm -f $(DATA_DIR)/*.csv $(DATA_DIR)/*.parquet
 
-# Run a quick test
+# Run a quick test to verify benchmarks compile
 test:
-	go test ./... -short
+	go test ./... -short -run=^$$ -bench=. -benchtime=1x

--- a/benchmarks/agg/agg_test.go
+++ b/benchmarks/agg/agg_test.go
@@ -1,0 +1,203 @@
+package agg
+
+import (
+	"testing"
+
+	"github.com/tnn1t1s/golars/benchmarks/data"
+	"github.com/tnn1t1s/golars/frame"
+)
+
+var testData struct {
+	small  *frame.DataFrame
+	medium *frame.DataFrame
+}
+
+func init() {
+	small, err := data.GenerateH2OAIData(data.H2OAISmall)
+	if err != nil {
+		panic(err)
+	}
+	testData.small = small
+
+	medium, err := data.GenerateH2OAIData(data.H2OAIMediumSafe)
+	if err != nil {
+		panic(err)
+	}
+	testData.medium = medium
+}
+
+// BenchmarkSum - Sum aggregation on numeric column
+func BenchmarkSum_Small(b *testing.B) {
+	benchmarkSum(b, testData.small)
+}
+
+func BenchmarkSum_Medium(b *testing.B) {
+	benchmarkSum(b, testData.medium)
+}
+
+func benchmarkSum(b *testing.B, df *frame.DataFrame) {
+	col, err := df.Column("v1")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result := col.Sum()
+		_ = result
+	}
+}
+
+// BenchmarkMean - Mean aggregation on numeric column
+func BenchmarkMean_Small(b *testing.B) {
+	benchmarkMean(b, testData.small)
+}
+
+func BenchmarkMean_Medium(b *testing.B) {
+	benchmarkMean(b, testData.medium)
+}
+
+func benchmarkMean(b *testing.B, df *frame.DataFrame) {
+	col, err := df.Column("v3")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result := col.Mean()
+		_ = result
+	}
+}
+
+// BenchmarkMin - Min aggregation
+func BenchmarkMin_Small(b *testing.B) {
+	benchmarkMin(b, testData.small)
+}
+
+func BenchmarkMin_Medium(b *testing.B) {
+	benchmarkMin(b, testData.medium)
+}
+
+func benchmarkMin(b *testing.B, df *frame.DataFrame) {
+	col, err := df.Column("v1")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result := col.Min()
+		_ = result
+	}
+}
+
+// BenchmarkMax - Max aggregation
+func BenchmarkMax_Small(b *testing.B) {
+	benchmarkMax(b, testData.small)
+}
+
+func BenchmarkMax_Medium(b *testing.B) {
+	benchmarkMax(b, testData.medium)
+}
+
+func benchmarkMax(b *testing.B, df *frame.DataFrame) {
+	col, err := df.Column("v1")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result := col.Max()
+		_ = result
+	}
+}
+
+// BenchmarkStd - Standard deviation
+func BenchmarkStd_Small(b *testing.B) {
+	benchmarkStd(b, testData.small)
+}
+
+func BenchmarkStd_Medium(b *testing.B) {
+	benchmarkStd(b, testData.medium)
+}
+
+func benchmarkStd(b *testing.B, df *frame.DataFrame) {
+	col, err := df.Column("v3")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result := col.Std()
+		_ = result
+	}
+}
+
+// BenchmarkMedian - Median aggregation
+func BenchmarkMedian_Small(b *testing.B) {
+	benchmarkMedian(b, testData.small)
+}
+
+func BenchmarkMedian_Medium(b *testing.B) {
+	benchmarkMedian(b, testData.medium)
+}
+
+func benchmarkMedian(b *testing.B, df *frame.DataFrame) {
+	col, err := df.Column("v3")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result := col.Median()
+		_ = result
+	}
+}
+
+// BenchmarkCount - Count aggregation
+func BenchmarkCount_Small(b *testing.B) {
+	benchmarkCount(b, testData.small)
+}
+
+func BenchmarkCount_Medium(b *testing.B) {
+	benchmarkCount(b, testData.medium)
+}
+
+func benchmarkCount(b *testing.B, df *frame.DataFrame) {
+	col, err := df.Column("v1")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result := col.Len()
+		_ = result
+	}
+}
+
+// BenchmarkVar - Variance
+func BenchmarkVar_Small(b *testing.B) {
+	benchmarkVar(b, testData.small)
+}
+
+func BenchmarkVar_Medium(b *testing.B) {
+	benchmarkVar(b, testData.medium)
+}
+
+func benchmarkVar(b *testing.B, df *frame.DataFrame) {
+	col, err := df.Column("v3")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result := col.Var()
+		_ = result
+	}
+}

--- a/benchmarks/filter/filter_test.go
+++ b/benchmarks/filter/filter_test.go
@@ -99,21 +99,21 @@ func benchmarkFilterString(b *testing.B, df *frame.DataFrame) {
 	}
 }
 
-// BenchmarkFilterIsIn - Filter using IsIn
-// Polars: df.filter(pl.col("id1").is_in(["id001", "id002", "id003"]))
-func BenchmarkFilterIsIn_Small(b *testing.B) {
-	benchmarkFilterIsIn(b, testData.small)
+// BenchmarkFilterOr - Filter with OR condition
+// Polars: df.filter((pl.col("v1") > 4) | (pl.col("v2") < 5))
+func BenchmarkFilterOr_Small(b *testing.B) {
+	benchmarkFilterOr(b, testData.small)
 }
 
-func BenchmarkFilterIsIn_Medium(b *testing.B) {
-	benchmarkFilterIsIn(b, testData.medium)
+func BenchmarkFilterOr_Medium(b *testing.B) {
+	benchmarkFilterOr(b, testData.medium)
 }
 
-func benchmarkFilterIsIn(b *testing.B, df *frame.DataFrame) {
+func benchmarkFilterOr(b *testing.B, df *frame.DataFrame) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		result, err := df.Filter(
-			expr.Col("id1").IsIn([]string{"id001", "id002", "id003"}),
+			expr.Col("v1").Gt(4).Or(expr.Col("v2").Lt(5)),
 		)
 		if err != nil {
 			b.Fatal(err)

--- a/benchmarks/sort/sort_test.go
+++ b/benchmarks/sort/sort_test.go
@@ -1,0 +1,127 @@
+package sort
+
+import (
+	"testing"
+
+	"github.com/tnn1t1s/golars/benchmarks/data"
+	"github.com/tnn1t1s/golars/frame"
+)
+
+var testData struct {
+	small  *frame.DataFrame
+	medium *frame.DataFrame
+}
+
+func init() {
+	small, err := data.GenerateH2OAIData(data.H2OAISmall)
+	if err != nil {
+		panic(err)
+	}
+	testData.small = small
+
+	medium, err := data.GenerateH2OAIData(data.H2OAIMediumSafe)
+	if err != nil {
+		panic(err)
+	}
+	testData.medium = medium
+}
+
+// BenchmarkSortSingleInt - Sort by single integer column
+func BenchmarkSortSingleInt_Small(b *testing.B) {
+	benchmarkSortSingleInt(b, testData.small)
+}
+
+func BenchmarkSortSingleInt_Medium(b *testing.B) {
+	benchmarkSortSingleInt(b, testData.medium)
+}
+
+func benchmarkSortSingleInt(b *testing.B, df *frame.DataFrame) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result, err := df.Sort("v1")
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = result
+	}
+}
+
+// BenchmarkSortSingleString - Sort by single string column
+func BenchmarkSortSingleString_Small(b *testing.B) {
+	benchmarkSortSingleString(b, testData.small)
+}
+
+func BenchmarkSortSingleString_Medium(b *testing.B) {
+	benchmarkSortSingleString(b, testData.medium)
+}
+
+func benchmarkSortSingleString(b *testing.B, df *frame.DataFrame) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result, err := df.Sort("id1")
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = result
+	}
+}
+
+// BenchmarkSortMultiColumn - Sort by multiple columns
+func BenchmarkSortMultiColumn_Small(b *testing.B) {
+	benchmarkSortMultiColumn(b, testData.small)
+}
+
+func BenchmarkSortMultiColumn_Medium(b *testing.B) {
+	benchmarkSortMultiColumn(b, testData.medium)
+}
+
+func benchmarkSortMultiColumn(b *testing.B, df *frame.DataFrame) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result, err := df.Sort("id1", "id2", "v1")
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = result
+	}
+}
+
+// BenchmarkSortDescending - Sort descending
+func BenchmarkSortDescending_Small(b *testing.B) {
+	benchmarkSortDescending(b, testData.small)
+}
+
+func BenchmarkSortDescending_Medium(b *testing.B) {
+	benchmarkSortDescending(b, testData.medium)
+}
+
+func benchmarkSortDescending(b *testing.B, df *frame.DataFrame) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result, err := df.SortDesc("v1")
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = result
+	}
+}
+
+// BenchmarkSortFloat - Sort by float column
+func BenchmarkSortFloat_Small(b *testing.B) {
+	benchmarkSortFloat(b, testData.small)
+}
+
+func BenchmarkSortFloat_Medium(b *testing.B) {
+	benchmarkSortFloat(b, testData.medium)
+}
+
+func benchmarkSortFloat(b *testing.B, df *frame.DataFrame) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		result, err := df.Sort("v3")
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = result
+	}
+}


### PR DESCRIPTION
## Summary
- Add sort benchmarks (single/multi column, ascending/descending, int/string/float)
- Add aggregation benchmarks (sum, mean, min, max, std, var, median, count)
- Update filter benchmarks (replace unsupported IsIn with Or condition)
- Expand Makefile with all benchmark suites (groupby, filter, join, sort, agg, io)
- Add configurable COUNT and TIMEOUT options for benchmark runs

## Benchmark Suites
```bash
make benchmark-agg      # Aggregation operations
make benchmark-filter   # Filter operations  
make benchmark-sort     # Sort operations
make benchmark-groupby  # GroupBy operations
make benchmark-join     # Join operations
make benchmark-io       # CSV/Parquet I/O
make benchmark-all      # Run all suites
```

## Test plan
- [x] All benchmark packages build successfully
- [x] Individual benchmark suites run and produce results
- [x] Makefile targets work correctly

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)